### PR TITLE
Add support for kubeconfig as data source in analyze command

### DIFF
--- a/pkg/analyze/data_source.go
+++ b/pkg/analyze/data_source.go
@@ -1,0 +1,116 @@
+package analyze
+
+import (
+	"context"
+	"fmt"
+	scyllaversioned "github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned"
+	scyllav1listers "github.com/scylladb/scylla-operator/pkg/client/scylla/listers/scylla/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/pager"
+)
+
+type DataSource struct {
+	PodLister            corev1listers.PodLister
+	ServiceLister        corev1listers.ServiceLister
+	SecretLister         corev1listers.SecretLister
+	ConfigMapLister      corev1listers.ConfigMapLister
+	ServiceAccountLister corev1listers.ServiceAccountLister
+	ScyllaClusterLister  scyllav1listers.ScyllaClusterLister
+}
+
+func BuildListerWithOptions[T any](
+	ctx context.Context,
+	factory func(cache.Indexer) T,
+	listFunc func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error),
+	options metav1.ListOptions,
+) (T, error) {
+	p := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
+		return listFunc(ctx, opts)
+	}))
+
+	// Prevent users from providing unwanted ones or tempering options that pager controls
+	options = metav1.ListOptions{
+		LabelSelector: options.LabelSelector,
+		FieldSelector: options.FieldSelector,
+	}
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"NamespaceIndex": cache.MetaNamespaceIndexFunc})
+	err := p.EachListItemWithAlloc(ctx, options, func(obj runtime.Object) error {
+		err := indexer.Add(obj)
+		if err != nil {
+			return fmt.Errorf("can't add object to indexer %v: %w", obj, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return *new(T), fmt.Errorf("can't iterate over list items: %w", err)
+	}
+
+	return factory(indexer), nil
+}
+
+func BuildLister[T any](ctx context.Context, factory func(cache.Indexer) T, listFunc func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error)) (T, error) {
+	return BuildListerWithOptions[T](ctx, factory, listFunc, metav1.ListOptions{})
+}
+
+func NewDataSourceFromClients(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	scyllaClient scyllaversioned.Interface,
+) (*DataSource, error) {
+	podLister, err := BuildLister(ctx, corev1listers.NewPodLister, func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+		return kubeClient.CoreV1().Pods(corev1.NamespaceAll).List(ctx, options)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't build pod lister: %w", err)
+	}
+
+	serviceLister, err := BuildLister(ctx, corev1listers.NewServiceLister, func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+		return kubeClient.CoreV1().Services(corev1.NamespaceAll).List(ctx, options)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't build service lister: %w", err)
+	}
+
+	secretLister, err := BuildLister(ctx, corev1listers.NewSecretLister, func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+		return kubeClient.CoreV1().Secrets(corev1.NamespaceAll).List(ctx, options)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't build secret lister: %w", err)
+	}
+
+	configMapLister, err := BuildLister(ctx, corev1listers.NewConfigMapLister, func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+		return kubeClient.CoreV1().ConfigMaps(corev1.NamespaceAll).List(ctx, options)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't build config map lister: %w", err)
+	}
+
+	serviceAccountLister, err := BuildLister(ctx, corev1listers.NewServiceAccountLister, func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+		return kubeClient.CoreV1().ServiceAccounts(corev1.NamespaceAll).List(ctx, options)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't build service account lister: %w", err)
+	}
+
+	scyllaClusterLister, err := BuildLister(ctx, scyllav1listers.NewScyllaClusterLister, func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+		return scyllaClient.ScyllaV1().ScyllaClusters(corev1.NamespaceAll).List(ctx, options)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("can't build scylla cluster lister: %w", err)
+	}
+
+	return &DataSource{
+		PodLister:            podLister,
+		ServiceLister:        serviceLister,
+		SecretLister:         secretLister,
+		ConfigMapLister:      configMapLister,
+		ServiceAccountLister: serviceAccountLister,
+		ScyllaClusterLister:  scyllaClusterLister,
+	}, nil
+}

--- a/pkg/analyze/data_source_test.go
+++ b/pkg/analyze/data_source_test.go
@@ -1,0 +1,530 @@
+package analyze
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	scyllav1 "github.com/scylladb/scylla-operator/pkg/api/scylla/v1"
+	"github.com/scylladb/scylla-operator/pkg/client/scylla/clientset/versioned/fake"
+	"github.com/scylladb/scylla-operator/pkg/helpers/slices"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	v1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestBuildLister(t *testing.T) {
+	t.Parallel()
+	buildListerDummyTests := []struct {
+		name               string
+		listerFactory      func(i cache.Indexer) interface{}
+		listerFunc         func(lister interface{}) ([]runtime.Object, error)
+		expectedListerType reflect.Type
+		expectedObjects    []runtime.Object
+	}{
+		{
+			name: "empty pod lister",
+			listerFactory: func(i cache.Indexer) interface{} {
+				return v1.NewPodLister(i)
+			},
+			listerFunc: func(lister interface{}) ([]runtime.Object, error) {
+				objects, err := lister.(v1.PodLister).List(labels.Everything())
+				return slices.ConvertSlice(objects, convertToRuntimeObject), err
+			},
+			expectedListerType: reflect.TypeFor[*v1.PodLister](),
+		},
+		{
+			name: "nonempty pod lister",
+			listerFactory: func(i cache.Indexer) interface{} {
+				return v1.NewPodLister(i)
+			},
+			listerFunc: func(lister interface{}) ([]runtime.Object, error) {
+				objects, err := lister.(v1.PodLister).List(labels.Everything())
+				return slices.ConvertSlice(objects, convertToRuntimeObject), err
+			},
+			expectedListerType: reflect.TypeFor[*v1.PodLister](),
+			expectedObjects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "test",
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "test",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range buildListerDummyTests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var objectsAsRawExtension []runtime.RawExtension
+			for _, obj := range tc.expectedObjects {
+				objectsAsRawExtension = append(objectsAsRawExtension, runtime.RawExtension{
+					Object: obj,
+				})
+			}
+
+			ctx := context.Background()
+			listFunc := func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+				return &metav1.List{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items:    objectsAsRawExtension,
+				}, nil
+			}
+
+			lister, err := BuildLister(ctx, tc.listerFactory, listFunc)
+			if err != nil {
+				t.Fatalf("BuildLister returned an error: %v", err)
+			}
+			if equality.Semantic.DeepEqual(lister, tc.expectedListerType) {
+				t.Fatalf("expected '%v' got: '%v'", tc.expectedListerType, reflect.TypeOf(lister))
+			}
+
+			objects, err := tc.listerFunc(lister)
+			if err != nil {
+				t.Fatalf("dummyLister.List returned an error: %v", err)
+			}
+
+			sort.Slice(objects, func(i, j int) bool {
+				return compareRuntimeObjects(objects[i], objects[j])
+			})
+
+			if !equality.Semantic.DeepEqual(objects, tc.expectedObjects) {
+				t.Errorf("expected and actual objects differ: %s", cmp.Diff(tc.expectedObjects, objects))
+			}
+		})
+	}
+}
+
+func TestNewDataSourceFromClients_SingleLister(t *testing.T) {
+	t.Parallel()
+	newDataSourceTests := []struct {
+		name              string
+		kubernetesObjects []runtime.Object
+		scyllaObjects     []runtime.Object
+		listerFunc        func(*DataSource) ([]runtime.Object, error)
+		expectedObjects   []runtime.Object
+		expectedErr       error
+	}{
+		{
+			name: "empty pod list",
+			kubernetesObjects: func() []runtime.Object {
+				return slices.FilterOut(newBasicKubernetesObjects(), func(obj runtime.Object) bool {
+					_, ok := obj.(*corev1.Pod)
+					return ok
+				})
+			}(),
+			scyllaObjects: newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.PodLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list pods: %w", err)
+				}
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{},
+			expectedErr:     nil,
+		},
+		{
+			name:              "nonempty pod list",
+			kubernetesObjects: newBasicKubernetesObjects(),
+			scyllaObjects:     newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.PodLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list pods: %w", err)
+				}
+
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "test",
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "test",
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "empty service list",
+			kubernetesObjects: func() []runtime.Object {
+				return slices.FilterOut(newBasicKubernetesObjects(), func(obj runtime.Object) bool {
+					_, ok := obj.(*corev1.Service)
+					return ok
+				})
+			}(),
+			scyllaObjects: newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				pods, err := ds.ServiceLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list services: %w", err)
+				}
+				return slices.ConvertSlice(pods, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{},
+			expectedErr:     nil,
+		},
+		{
+			name:              "nonempty service list",
+			kubernetesObjects: newBasicKubernetesObjects(),
+			scyllaObjects:     newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.ServiceLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list services: %w", err)
+				}
+
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service1",
+						Namespace: "test",
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service2",
+						Namespace: "test",
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "empty secret list",
+			kubernetesObjects: func() []runtime.Object {
+				return slices.FilterOut(newBasicKubernetesObjects(), func(obj runtime.Object) bool {
+					_, ok := obj.(*corev1.Secret)
+					return ok
+				})
+			}(),
+			scyllaObjects: newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.SecretLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list secrets: %w", err)
+				}
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{},
+			expectedErr:     nil,
+		},
+		{
+			name:              "nonempty secret list",
+			kubernetesObjects: newBasicKubernetesObjects(),
+			scyllaObjects:     newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.SecretLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list secrets: %w", err)
+				}
+
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: "test",
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret2",
+						Namespace: "test",
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "empty config map list",
+			kubernetesObjects: func() []runtime.Object {
+				return slices.FilterOut(newBasicKubernetesObjects(), func(obj runtime.Object) bool {
+					_, ok := obj.(*corev1.ConfigMap)
+					return ok
+				})
+			}(),
+			scyllaObjects: newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.ConfigMapLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list config maps: %w", err)
+				}
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{},
+			expectedErr:     nil,
+		},
+		{
+			name:              "nonempty config map list",
+			kubernetesObjects: newBasicKubernetesObjects(),
+			scyllaObjects:     newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.ConfigMapLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list config maps: %w", err)
+				}
+
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "configmap1",
+						Namespace: "test",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "configmap2",
+						Namespace: "test",
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "empty service account list",
+			kubernetesObjects: func() []runtime.Object {
+				return slices.FilterOut(newBasicKubernetesObjects(), func(obj runtime.Object) bool {
+					_, ok := obj.(*corev1.ServiceAccount)
+					return ok
+				})
+			}(),
+			scyllaObjects: newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.ServiceAccountLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list service accounts: %w", err)
+				}
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{},
+			expectedErr:     nil,
+		},
+		{
+			name:              "nonempty service account list",
+			kubernetesObjects: newBasicKubernetesObjects(),
+			scyllaObjects:     newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.ServiceAccountLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list service accounts: %w", err)
+				}
+
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "serviceaccount1",
+						Namespace: "test",
+					},
+				},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "serviceaccount2",
+						Namespace: "test",
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:              "empty scylla cluster list",
+			kubernetesObjects: newBasicKubernetesObjects(),
+			scyllaObjects: func() []runtime.Object {
+				return slices.FilterOut(newBasicScyllaObjects(), func(obj runtime.Object) bool {
+					_, ok := obj.(*scyllav1.ScyllaCluster)
+					return ok
+				})
+			}(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.ScyllaClusterLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list scylla clusters: %w", err)
+				}
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{},
+			expectedErr:     nil,
+		},
+		{
+			name:              "nonempty scylla cluster list",
+			kubernetesObjects: newBasicKubernetesObjects(),
+			scyllaObjects:     newBasicScyllaObjects(),
+			listerFunc: func(ds *DataSource) ([]runtime.Object, error) {
+				objects, err := ds.ScyllaClusterLister.List(labels.Everything())
+				if err != nil {
+					return nil, fmt.Errorf("can't list scylla clusters: %w", err)
+				}
+
+				return slices.ConvertSlice(objects, convertToRuntimeObject), nil
+			},
+			expectedObjects: []runtime.Object{
+				&scyllav1.ScyllaCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "scyllacluster1",
+						Namespace: "test",
+					},
+				},
+				&scyllav1.ScyllaCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "scyllacluster2",
+						Namespace: "test",
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range newDataSourceTests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			fakeClient := kubefake.NewSimpleClientset(tc.kubernetesObjects...)
+			scyllaFakeClient := fake.NewSimpleClientset(tc.scyllaObjects...)
+
+			dataSource, err := NewDataSourceFromClients(ctx, fakeClient, scyllaFakeClient)
+			if !reflect.DeepEqual(err, tc.expectedErr) {
+				t.Fatalf("expected error: %v, got: %v", tc.expectedErr, err)
+			}
+
+			objects, err := tc.listerFunc(dataSource)
+			if err != nil {
+				t.Fatalf("unexpected error from lister func: %v", err)
+			}
+
+			sort.Slice(objects, func(i, j int) bool {
+				return compareRuntimeObjects(objects[i], objects[j])
+			})
+
+			if !equality.Semantic.DeepEqual(objects, tc.expectedObjects) {
+				t.Errorf("expected and actual objects differ: %s", cmp.Diff(tc.expectedObjects, objects))
+			}
+		})
+	}
+}
+
+func compareRuntimeObjects(a runtime.Object, b runtime.Object) bool {
+	valueA := reflect.ValueOf(a).Elem().FieldByName("ObjectMeta")
+	valueB := reflect.ValueOf(b).Elem().FieldByName("ObjectMeta")
+	metaA := valueA.Interface().(metav1.ObjectMeta)
+	metaB := valueB.Interface().(metav1.ObjectMeta)
+	return metaA.Namespace+metaA.Name < metaB.Namespace+metaB.Name
+}
+
+func convertToRuntimeObject[T runtime.Object](v T) runtime.Object {
+	return runtime.Object(v)
+}
+
+func newBasicKubernetesObjects() []runtime.Object {
+	return []runtime.Object{
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod1",
+				Namespace: "test",
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod2",
+				Namespace: "test",
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service1",
+				Namespace: "test",
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service2",
+				Namespace: "test",
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret1",
+				Namespace: "test",
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret2",
+				Namespace: "test",
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "configmap1",
+				Namespace: "test",
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "configmap2",
+				Namespace: "test",
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "serviceaccount1",
+				Namespace: "test",
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "serviceaccount2",
+				Namespace: "test",
+			},
+		},
+	}
+}
+
+func newBasicScyllaObjects() []runtime.Object {
+	return []runtime.Object{
+		&scyllav1.ScyllaCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scyllacluster1",
+				Namespace: "test",
+			},
+		},
+		&scyllav1.ScyllaCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scyllacluster2",
+				Namespace: "test",
+			},
+		},
+	}
+}


### PR DESCRIPTION
Adds a kubeconfig data source and builds-up analyze command framework

**Which issue is resolved by this Pull Request:**
Resolves #4 